### PR TITLE
Enable ATA_DMA

### DIFF
--- a/config.seabios-128k
+++ b/config.seabios-128k
@@ -2,7 +2,7 @@
 # need to turn off features (xhci,uas) to make it fit into 128k
 CONFIG_QEMU=y
 CONFIG_ROM_SIZE=128
-CONFIG_ATA_DMA=n
+CONFIG_ATA_DMA=y
 CONFIG_BOOTSPLASH=n
 CONFIG_XEN=n
 CONFIG_USB_OHCI=n

--- a/config.seabios-256k
+++ b/config.seabios-256k
@@ -1,4 +1,4 @@
 # for qemu machine types 2.0 + newer
 CONFIG_QEMU=y
 CONFIG_ROM_SIZE=256
-CONFIG_ATA_DMA=n
+CONFIG_ATA_DMA=y

--- a/seabios.spec
+++ b/seabios.spec
@@ -4,7 +4,8 @@
 
 Name:           seabios
 Version:        1.13.0
-Release:        2%{?dist}
+Release:        3%{?dist}
+Epoch:          1000
 Summary:        Open-source legacy BIOS implementation
 
 License:        LGPLv3


### PR DESCRIPTION
It was initially disabled in this qemu commit (then synced into Fedora
seabios package):

    commit b435a8f8c8cf544f53728e26333838162ab8022c
    Author: Gerd Hoffmann <kraxel@redhat.com>
    Date:   Mon Mar 18 13:42:49 2019 +0100

        seabios: turn off CONFIG_ATA_DMA

        There have been regressions reported, when booting FreeDOS.
        https://www.mail-archive.com/qemu-devel@nongnu.org/msg593254.html

        Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>

Unfortunately, disabling ATA_DMA has a nasty side effect - makes grub
unusably slow. Working grub is more important in Qubes than FreeDOS.

Fixes QubesOS/qubes-issues#5790